### PR TITLE
[FIX] cannot-filter-comments | Comment-type questions now update its …

### DIFF
--- a/src/alternativeVizualizersWrapper.ts
+++ b/src/alternativeVizualizersWrapper.ts
@@ -45,7 +45,9 @@ export class AlternativeVisualizersWrapper extends VisualizerBase {
   }
 
   update(data: Array<{ [index: string]: any }>) {
-    this.visualizer.update(data);
+    this.visualizers.forEach(v => v.update(data));
+    this.visualizerContainer.innerHTML = "";
+    this.visualizer.render(this.visualizerContainer);
   }
 
   destroy() {


### PR DESCRIPTION
…values as responses get filtered interactively.

Problem:
I noticed that one of the features of survey-analytics "Interactive filtering for the select type questions" was not filtering the comment-type questions as well. Ther data was correctly updated as the filter applied but changes were not rendered on the screen. 

Solution:
When an update of the visualizer's data should be done, in the `AlternativeVisualizersWrapper.ts` I applied the same procedure implemented in the `SelectBase.ts`. That is: destroying the content of the HTML node and rendering the node with the updated content.
The fix applies for both display modes: Wordcloud and Texts in table.

How to test:
1. Use a Survey with select type questions and comment type questions.
2. Render the responses using the VisualizationPanel.
3. Select one bar to interactively filter responses.
4. Make sure that only comments belonging to the filtered responses are shown and not all of them.