### PR TITLE
Autofix: Visualize Text Entry Questions as Charts - Bars are duplicated when changing a bar type

### DIFF
--- a/examples/chart_text.js
+++ b/examples/chart_text.js
@@ -1,4 +1,5 @@
 function CustomVisualizer(question, data) {
+  var chartData = [];
   var values = [];
 
   var visualizer = new SurveyAnalytics.SelectBasePlotly(
@@ -7,8 +8,11 @@ function CustomVisualizer(question, data) {
     { },
     "textChartVisualizer"
   );
-  visualizer.getValues = function () { return values; };
+  visualizer.getValues = function () { return chartData; };
   visualizer.getLabels = function () { return values; };
+  visualizer.getCalculatedValuesCore = function () {
+    values = [];
+    chartData = [];
   visualizer.getCalculatedValuesCore = function () {
     var result = {};
     visualizer.surveyData.forEach(function (row) {
@@ -23,8 +27,9 @@ function CustomVisualizer(question, data) {
     });
 
     values.push.apply(values, Object.keys(result));
+    chartData = values.map(function(value) { return result[value]; });
+    return [chartData];
     return [values.map(function(value) { return result[value]; })];
-  };
 
   return visualizer;
 }


### PR DESCRIPTION
Updated the CustomVisualizer function to clear the values array before recalculating, preventing duplication of bars when changing chart types. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    