### PR TITLE
perf(tabulator): use Map for O(1) column lookup in accessorDownload

### DIFF
--- a/src/tables/table.ts
+++ b/src/tables/table.ts
@@ -117,6 +117,7 @@ export abstract class Table {
   protected extensions: TableExtensions;
   private haveCommercialLicense = false;
   protected _columns: Array<IColumn>;
+  private _columnsByName: Map<string, IColumn> | null = null;
   constructor(
     protected _survey: SurveyModel,
     protected data: Array<Object> | GetDataFn,
@@ -155,7 +156,7 @@ export abstract class Table {
     this.isInitialized = false;
     this.currentPageSize = this.options.pageSize || 5;
     this.currentPageNumber = 1;
-    this._columns = this.buildColumns(this._survey);
+    this.setColumns(this.buildColumns(this._survey));
     this.initTableData(this.data);
     localization.currentLocale = this._survey.locale;
 
@@ -282,9 +283,18 @@ export abstract class Table {
   }
 
   public set columns(columns: Array<IColumn>) {
-    this._columns = columns;
+    this.setColumns(columns);
     this.refresh(true);
     this.stateChanged();
+  }
+
+  protected setColumns(columns: Array<IColumn>): void {
+    this._columns = columns;
+    this.invalidateColumnsByNameCache();
+  }
+
+  protected invalidateColumnsByNameCache(): void {
+    this._columnsByName = null;
   }
 
   private isInitTableDataProcessingValue: boolean;
@@ -327,7 +337,13 @@ export abstract class Table {
   }
 
   public getColumnByName(columnName: string): IColumn {
-    return this._columns.filter((column) => column.name === columnName)[0];
+    if(!this._columnsByName) {
+      this._columnsByName = new Map<string, IColumn>();
+      for(const column of this._columns) {
+        this._columnsByName.set(column.name, column);
+      }
+    }
+    return this._columnsByName.get(columnName);
   }
 
   public setColumnVisibility(columnName: string, isVisible: boolean) {
@@ -487,7 +503,7 @@ export abstract class Table {
         columns.push(column);
       }
     });
-    this._columns = this._columns.sort((col1, col2) => col1.visibleIndex - col2.visibleIndex);
+    this.setColumns(this._columns.sort((col1, col2) => col1.visibleIndex - col2.visibleIndex));
   }
 
   /**
@@ -518,7 +534,7 @@ export abstract class Table {
 
       return column;
     });
-    this._columns = [].concat(updatedElements);
+    this.setColumns([].concat(updatedElements));
     this.onPermissionsChangedCallback &&
       this.onPermissionsChangedCallback(this);
   }

--- a/src/tables/tabulator.ts
+++ b/src/tables/tabulator.ts
@@ -151,6 +151,7 @@ export class Tabulator extends Table {
   public tabulatorTables: TabulatorFull = null;
   private tableContainer: HTMLElement = null;
   private currentDownloadType: string = "";
+  private columnMap: Map<string, IColumn> = new Map<string, IColumn>();
 
   protected supportSoftRefresh() {
     return true;
@@ -528,7 +529,10 @@ export class Tabulator extends Table {
     if(Array.isArray(this.data)) {
       const columnDefinition = columnComponent.getDefinition();
       const questionName = columnDefinition.field;
-      const column = this.columns.filter(col => col.name === questionName)[0];
+      if(this.columnMap.size === 0) {
+        this.initializeColumnMap();
+      }
+      const column = this.columnMap.get(questionName);
       if(!!column && rowComponent) {
         const dataRow = rowComponent.getData().surveyOriginalData;
         const dataCell = dataRow[questionName];
@@ -551,6 +555,12 @@ export class Tabulator extends Table {
     }
     return cellData;
   };
+
+  private initializeColumnMap(): void {
+    for(const col of this.columns) {
+      this.columnMap.set(col.name, col);
+    }
+  }
 
   private getTitleFormatter(
     cell: any,

--- a/src/tables/tabulator.ts
+++ b/src/tables/tabulator.ts
@@ -151,7 +151,6 @@ export class Tabulator extends Table {
   public tabulatorTables: TabulatorFull = null;
   private tableContainer: HTMLElement = null;
   private currentDownloadType: string = "";
-  private columnMap: Map<string, IColumn> = new Map<string, IColumn>();
 
   protected supportSoftRefresh() {
     return true;
@@ -529,10 +528,7 @@ export class Tabulator extends Table {
     if(Array.isArray(this.data)) {
       const columnDefinition = columnComponent.getDefinition();
       const questionName = columnDefinition.field;
-      if(this.columnMap.size === 0) {
-        this.initializeColumnMap();
-      }
-      const column = this.columnMap.get(questionName);
+      const column = this.getColumnByName(questionName);
       if(!!column && rowComponent) {
         const dataRow = rowComponent.getData().surveyOriginalData;
         const dataCell = dataRow[questionName];
@@ -555,12 +551,6 @@ export class Tabulator extends Table {
     }
     return cellData;
   };
-
-  private initializeColumnMap(): void {
-    for(const col of this.columns) {
-      this.columnMap.set(col.name, col);
-    }
-  }
 
   private getTitleFormatter(
     cell: any,

--- a/tests/tables/tables.test.ts
+++ b/tests/tables/tables.test.ts
@@ -1108,6 +1108,40 @@ test("check set state with columns which not inside survey", () => {
   expect(table.columns[1].getCellData(table, data).question).toBe(undefined);
 });
 
+test("getColumnByName uses Map cache and invalidates after state adds columns", () => {
+  const survey = new SurveyModel({
+    questions: [{ type: "text", name: "q1" }]
+  });
+  const table = new TableTest(survey, [{ q1: "text1", q2: "text2" }], {}, []);
+
+  expect(table.getColumnByName("q1").name).toBe("q1");
+  expect(table.getColumnByName("q2")).toBeUndefined();
+
+  table.state = {
+    elements: [
+      {
+        dataType: ColumnDataType.Text,
+        displayName: "q1",
+        isPublic: true,
+        isVisible: true,
+        location: QuestionLocation.Column,
+        name: "q1"
+      },
+      {
+        dataType: ColumnDataType.Text,
+        displayName: "q2",
+        isPublic: true,
+        isVisible: true,
+        location: QuestionLocation.Column,
+        name: "q2"
+      }
+    ]
+  };
+
+  expect(table.getColumnByName("q2").name).toBe("q2");
+  expect(table.getColumnByName("q1").name).toBe("q1");
+});
+
 test("check checkbox column with multi comments", () => {
   const json = { "elements":
          [{

--- a/tests/tables/tabulator.test.ts
+++ b/tests/tables/tabulator.test.ts
@@ -3,6 +3,7 @@ import { Question, SurveyModel } from "survey-core";
 import { Tabulator } from "../../src/entries/tabulator-umd";
 import { TableExtensions } from "../../src/tables/extensions/tableextensions";
 import { Table } from "../../src/tables/table";
+import { ColumnDataType } from "../../src/tables/config";
 import { vi } from "vitest";
 
 vi.mock("tabulator-tables", async () => {
@@ -309,6 +310,24 @@ test("image and file export formatter", () => {
 
   const imageCell = accessorDownload(undefined, data[0], undefined, undefined, { getDefinition: () => ({ field: "signature" }) }, { getData: () => { return { "surveyOriginalData": data[0] }; } });
   expect(imageCell).toBe("signature");
+
+  // After state introduces an extra column, download accessor must still resolve columns via refreshed cache.
+  tabulator.state = {
+    ...tabulator.state,
+    elements: [
+      ...tabulator.state.elements,
+      {
+        name: "extra",
+        displayName: "extra",
+        dataType: ColumnDataType.Text,
+        isVisible: true,
+        isPublic: true,
+        location: 0,
+      }
+    ]
+  };
+  expect(tabulator.getColumnByName("extra")?.name).toBe("extra");
+  expect(tabulator.getColumnByName("image")?.name).toBe("image");
 });
 test("check getDataPosition returns correct index", () => {
   const surveyJson = {


### PR DESCRIPTION
[T27717 - Performance improvements for accessorDownload](https://surveyjs.answerdesk.io/internal/ticket/details/T27717)

Replace this.columns.filter(col => col.name === questionName)[0] (O(N) linear scan per cell) with a lazily-initialized Map<string, IColumn> for O(1) lookup. The map is built once on first access and reused for all subsequent calls.

For exports with M rows and N columns, this reduces total lookup cost from O(M * N^2) to O(M * N). For large surveys (50+ questions, 10k+ responses) this eliminates a measurable bottleneck during CSV/XLSX export.